### PR TITLE
Fix compilation on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package (Python3
     COMPONENTS Interpreter Development.Module
     REQUIRED
 )
-message(STATUS "Found Python ${Python3_VERSION} at ${Python3_EXECUTABLE} (include_dirs=${Python3_INCLUDE_DIRS})")
+message(STATUS "Found Python ${Python3_VERSION} at ${Python3_EXECUTABLE}")
 
 # ---------------------------------------------------------------
 # Define library (python extension) "pymp3.[so|pyd]"
@@ -51,12 +51,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     LINKER_LANGUAGE C
 )
 
-
-# Tell the compiler/linker where to find Python.h and library files
-set_target_properties(${PROJECT_NAME} PROPERTIES 
-    INCLUDE_DIRECTORIES "${Python3_INCLUDE_DIRS}"
-    LINK_DIRECTORIES "${Python3_LIBRARY_DIRS}"
-)
+target_link_libraries(${PROJECT_NAME} PRIVATE Python3::Module)
 
 target_compile_options(${PROJECT_NAME}
     PRIVATE

--- a/README.md
+++ b/README.md
@@ -213,4 +213,3 @@ If you want to use the system-installed lame/mad, then pass the following parame
 TODO:
 
   - Allow user to define PYMP3_USE_SYSTEM_LIBMAD/LAME via environment variables, read them in setup.py and pass to cmake
-  - Make it compile on Mac OSX


### PR DESCRIPTION
Instead of passing through INCLUDE_DIRS and LIBRARY_DIRS ourselves, we can use the target created by FindPython3.